### PR TITLE
Fix Unexpected Behavior in UnturnedPlayer.Ban

### DIFF
--- a/Rocket.Unturned/Player/UnturnedPlayer.cs
+++ b/Rocket.Unturned/Player/UnturnedPlayer.cs
@@ -272,7 +272,12 @@ namespace Rocket.Unturned.Player
 
         public void Ban(string reason, uint duration)
         {
-            Provider.ban(this.CSteamID, reason, duration);
+            Ban(reason, duration, CSteamID.Nil);
+        }
+
+        public void Ban(string reason, uint duration, CSteamID instigator)
+        {
+            Provider.requestBanPlayer(instigator, this.CSteamID, Parser.getUInt32FromIP(this.IP), reason, duration);
         }
 
         public void Admin(bool admin)


### PR DESCRIPTION
https://github.com/SmartlyDressedGames/Unturned-3.x-Community/issues/1667

Copy-pasted description:

I believe, although I cannot be sure, that UnturnedPlayer.Ban is using Provider.ban as seen [here](https://github.com/RocketMod/Rocket.Unturned/blob/legacy/Rocket.Unturned/Player/UnturnedPlayer.cs#L275)

Using Provider.ban results in the player being kicked but the duration not applying, and the ban not being saved in SteamBlacklist.list.

If someone were to use UnturnedPlayer.Ban they would probably expect it to last the duration they specify. To correct this, I believe UnturnedPlayer.Ban should be using Provider.requestBanPlayer instead.

This PR replaces Provider.ban with Provider.requestBanPlayer to correct the problem.