### PR TITLE
Fix prefix and suffix, commands execution otimization.

### DIFF
--- a/Rocket.Unturned/Permissions/UnturnedPermissions.cs
+++ b/Rocket.Unturned/Permissions/UnturnedPermissions.cs
@@ -1,9 +1,7 @@
 ﻿using Rocket.API;
-using Rocket.API.Serialisation;
 using Rocket.Core;
 using Rocket.Unturned.Chat;
 using Rocket.Unturned.Extensions;
-using Rocket.Unturned.Player;
 using SDG.Unturned;
 using Steamworks;
 using System;
@@ -19,39 +17,40 @@ namespace Rocket.Unturned.Permissions
         public delegate void JoinRequested(CSteamID player, ref ESteamRejection? rejectionReason);
         public static event JoinRequested OnJoinRequested;
         
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         internal static bool CheckPermissions(SteamPlayer caller, string permission)
         {
-            UnturnedPlayer player = caller.ToUnturnedPlayer();
+            var player = caller.ToUnturnedPlayer();
 
-            Regex r = new Regex("^\\/\\S*");
-            string requestedCommand = r.Match(permission.ToLower()).Value.TrimStart('/').ToLower();
 
-            IRocketCommand command = R.Commands.GetCommand(requestedCommand);
-            double cooldown = R.Commands.GetCooldown(player, command);
+            var regex = new Regex("^\\/\\S*");
+            var requestedCommand = regex.Match(permission.ToLower()).Value.TrimStart('/').ToLower();
 
-            if (command != null)
-            {
-                if (R.Permissions.HasPermission(player, command))
-                {
-                    if (cooldown > 0)
-                    {
-                        UnturnedChat.Say(player, R.Translate("command_cooldown", cooldown), Color.red);
-                        return false;
-                    }
-                    return true;
-                }
-                else
-                {
-                    UnturnedChat.Say(player, R.Translate("command_no_permission"), Color.red);
-                    return false;
-                }
-            }
-            else
+
+            //this will prevent 'R.Commands.GetCooldow()' to be called keeping some performance
+            var command = R.Commands.GetCommand(requestedCommand);
+            if (command == null)
             {
                 UnturnedChat.Say(player, U.Translate("command_not_found"), Color.red);
                 return false;
+
             }
+
+            if (!R.Permissions.HasPermission(player, command))
+            {
+                UnturnedChat.Say(player, R.Translate("command_no_permission"), Color.red);
+                return false;
+            }
+
+
+            var cooldown = R.Commands.GetCooldown(player, command);
+            if (cooldown <= 0)
+                return true;
+
+
+            UnturnedChat.Say(player, R.Translate("command_cooldown", cooldown), Color.red);
+            return false;
         }
 
         internal static bool CheckValid(ValidateAuthTicketResponse_t r)
@@ -60,53 +59,56 @@ namespace Rocket.Unturned.Permissions
 
             try
             {
-
                 var playerGroups = R.Permissions.GetGroups(new RocketPlayer(r.m_SteamID.ToString()), true);
 
-                string prefix = playerGroups.FirstOrDefault(x => !string.IsNullOrEmpty(x.Prefix))?.Prefix ?? "";
-                string suffix = playerGroups.FirstOrDefault(x => !string.IsNullOrEmpty(x.Suffix))?.Suffix ?? "";
 
-                if (prefix != "" || suffix != "") 
+                var prefix = playerGroups.FirstOrDefault(x => !string.IsNullOrEmpty(x.Prefix))?.Prefix ?? "";
+                var suffix = playerGroups.FirstOrDefault(x => !string.IsNullOrEmpty(x.Suffix))?.Suffix ?? "";
+
+
+                var steamPending = Provider.pending.FirstOrDefault(x => x.playerID.steamID == r.m_SteamID);
+                if (steamPending != null)
                 {
-                    SteamPending steamPending = Provider.pending.FirstOrDefault(x => x.playerID.steamID == r.m_SteamID);
-                    if (steamPending != null)
+                    if (!string.IsNullOrEmpty(prefix))
                     {
-                        if (prefix != "" && !steamPending.playerID.characterName.StartsWith(prefix)) 
-                        {
-                            steamPending.playerID.characterName = $"{prefix}{steamPending.playerID.characterName}";
-                        }
-                        if (suffix != "" && !steamPending.playerID.characterName.EndsWith(suffix)) 
-                        {
-                            steamPending.playerID.characterName = $"{steamPending.playerID.characterName}{suffix}";
-                        }
+                        steamPending.playerID.characterName = $"{prefix}{steamPending.playerID.characterName}";
+                    }
+
+
+                    if (!string.IsNullOrEmpty(suffix))
+                    {
+                        steamPending.playerID.characterName += suffix;
                     }
                 }
-
             }
             catch (Exception ex)
             {
                 Core.Logging.Logger.Log($"Failed adding prefix/suffix to player {r.m_SteamID}: {ex}");
             }
 
-            if (OnJoinRequested != null)
+
+            if (OnJoinRequested == null)
+                return true;
+
+
+            foreach (var handler in OnJoinRequested.GetInvocationList().Cast<JoinRequested>())
             {
-                foreach (var handler in OnJoinRequested.GetInvocationList().Cast<JoinRequested>())
+                try
                 {
-                    try
-                    {
-                        handler(r.m_SteamID, ref reason);
-                        if (reason != null)
-                        {
-                            Provider.reject(r.m_SteamID, reason.Value);
-                            return false;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Core.Logging.Logger.LogException(ex);
-                    }
+                    handler(r.m_SteamID, ref reason);
+                    if (!reason.HasValue) 
+                        continue;
+
+
+                    Provider.reject(r.m_SteamID, reason.Value);
+                    return false;
+                }
+                catch (Exception ex)
+                {
+                    Core.Logging.Logger.LogException(ex);
                 }
             }
+
             return true;
         }
     }

--- a/Rocket.Unturned/U.cs
+++ b/Rocket.Unturned/U.cs
@@ -272,10 +272,14 @@ namespace Rocket.Unturned
                 shouldExecuteCommand = false;
             };
 
-            Provider.onCheckValid += (ValidateAuthTicketResponse_t callback, ref bool isValid) =>
+            //this is no being calle :/
+            Provider.onCheckValidWithExplanation += (ValidateAuthTicketResponse_t callback, ref bool isValid, ref string explanation) =>
             {
-                if(isValid)
-                    isValid = UnturnedPermissions.CheckValid(callback);
+                if (!isValid)
+                    return;
+
+
+                isValid = UnturnedPermissions.CheckValid(callback);
             };
     }
 


### PR DESCRIPTION
About permissions; I did some check before starting call 'random' functions that will not be used in some cases. 
Example:
```
IRocketCommand command = R.Commands.GetCommand(requestedCommand);
double cooldown = R.Commands.GetCooldown(player, command);
```
I command does not exist, rocketmod should not call GetCooldown.

About prefixes and suffixes: i changed the event from `Provider.onCheckValid` to `Provider.onCheckValidWithExplanation` and some otimizations.

btw rocketmod currently listen `Provider.onCheckValidWithExplanation` so `Provider.onCheckValid` is never called

